### PR TITLE
add buildHTML helper that accepts *strings.Builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ test:
 
 run:
 	go run examples/main.go
+
+bench:
+	go test -bench .

--- a/dom.go
+++ b/dom.go
@@ -77,11 +77,11 @@ type Attribute struct {
 }
 
 // HTML returns the HTML representation of the attribute.
-func (a Attribute) HTML(sb *strings.Builder) *strings.Builder {
-	if sb == nil {
-		sb = &strings.Builder{}
-	}
+func (a Attribute) HTML() template.HTML {
+	return template.HTML(a.buildHTML(&strings.Builder{}).String())
+}
 
+func (a Attribute) buildHTML(sb *strings.Builder) *strings.Builder {
 	valueHTML := a.ValueHTML
 	if valueHTML == "" {
 		valueHTML = template.HTMLAttr(template.HTMLEscapeString(a.ValueText))
@@ -108,11 +108,11 @@ type Node struct {
 }
 
 // HTML returns the HTML representation of the node.
-func (e Node) HTML(sb *strings.Builder) *strings.Builder {
-	if sb == nil {
-		sb = &strings.Builder{}
-	}
+func (e Node) HTML() template.HTML {
+	return template.HTML(e.buildHTML(&strings.Builder{}).String())
+}
 
+func (e Node) buildHTML(sb *strings.Builder) *strings.Builder {
 	if e.Name == "" {
 		if e.InnerHTML != "" {
 			sb.WriteString(string(e.InnerHTML))
@@ -127,7 +127,7 @@ func (e Node) HTML(sb *strings.Builder) *strings.Builder {
 
 	for _, attr := range e.Attributes {
 		sb.WriteString(" ")
-		attr.HTML(sb)
+		attr.buildHTML(sb)
 	}
 	sb.WriteString(">")
 	if e.InnerHTML != "" {
@@ -136,7 +136,7 @@ func (e Node) HTML(sb *strings.Builder) *strings.Builder {
 		sb.WriteString(template.HTMLEscapeString(e.InnerText))
 	} else {
 		for _, child := range e.Children {
-			child.HTML(sb)
+			child.buildHTML(sb)
 		}
 	}
 	sb.WriteString("</" + tagName + ">")

--- a/dom.go
+++ b/dom.go
@@ -77,12 +77,20 @@ type Attribute struct {
 }
 
 // HTML returns the HTML representation of the attribute.
-func (a Attribute) HTML() template.HTML {
+func (a Attribute) HTML(sb *strings.Builder) *strings.Builder {
+	if sb == nil {
+		sb = &strings.Builder{}
+	}
+
 	valueHTML := a.ValueHTML
 	if valueHTML == "" {
 		valueHTML = template.HTMLAttr(template.HTMLEscapeString(a.ValueText))
 	}
-	return template.HTML(template.HTMLEscapeString(a.Name) + "=\"" + string(valueHTML) + "\"")
+	sb.WriteString(template.HTMLEscapeString(a.Name))
+	sb.WriteString("=\"")
+	sb.WriteString(string(valueHTML))
+	sb.WriteString("\"")
+	return sb
 }
 
 // Node represents a HTML element.
@@ -100,31 +108,39 @@ type Node struct {
 }
 
 // HTML returns the HTML representation of the node.
-func (e Node) HTML() template.HTML {
+func (e Node) HTML(sb *strings.Builder) *strings.Builder {
+	if sb == nil {
+		sb = &strings.Builder{}
+	}
+
 	if e.Name == "" {
 		if e.InnerHTML != "" {
-			return e.InnerHTML
+			sb.WriteString(string(e.InnerHTML))
+			return sb
 		}
-		return template.HTML(template.HTMLEscapeString(e.InnerText))
-	}
-
-	var attrsHTML strings.Builder
-	for _, attr := range e.Attributes {
-		attrsHTML.WriteString(string(" " + attr.HTML()))
-	}
-
-	var childrenHTML strings.Builder
-	childrenHTML.WriteString(string(e.InnerHTML))
-	if childrenHTML.Len() == 0 {
-		childrenHTML.WriteString(template.HTMLEscapeString(e.InnerText))
-	}
-	if childrenHTML.Len() == 0 {
-		for _, child := range e.Children {
-			childrenHTML.WriteString(string(child.HTML()))
-		}
+		sb.WriteString(template.HTMLEscapeString(e.InnerText))
+		return sb
 	}
 	tagName := template.HTMLEscapeString(e.Name)
-	return template.HTML("<" + tagName + attrsHTML.String() + ">" + childrenHTML.String() + "</" + tagName + ">")
+	sb.WriteString("<")
+	sb.WriteString(tagName)
+
+	for _, attr := range e.Attributes {
+		sb.WriteString(" ")
+		attr.HTML(sb)
+	}
+	sb.WriteString(">")
+	if e.InnerHTML != "" {
+		sb.WriteString(string(e.InnerHTML))
+	} else if e.InnerText != "" {
+		sb.WriteString(template.HTMLEscapeString(e.InnerText))
+	} else {
+		for _, child := range e.Children {
+			child.HTML(sb)
+		}
+	}
+	sb.WriteString("</" + tagName + ">")
+	return sb
 }
 
 // Helper functions for every html element, using Element() and Text() helpers.

--- a/dom_test.go
+++ b/dom_test.go
@@ -4,22 +4,20 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"strings"
 	"testing"
 
 	"github.com/choonkeat/dom-go"
 )
 
 func TestAttribute(t *testing.T) {
-	var gotHTML, wantHTML strings.Builder
-	dom.Div(
+	got := dom.Div(
 		dom.Attrs(
 			"class", "greeting",
 			"style", "color: red;",
 		),
 		dom.Text("Hello, world!"),
-	).HTML(&gotHTML)
-	dom.Node{
+	)
+	want := dom.Node{
 		Name: "div",
 		Attributes: []dom.Attribute{
 			{Name: "class", ValueText: "greeting"},
@@ -28,9 +26,9 @@ func TestAttribute(t *testing.T) {
 		Children: []dom.Node{
 			{InnerText: "Hello, world!"},
 		},
-	}.HTML(&wantHTML)
-	if gotHTML.String() != wantHTML.String() {
-		t.Fatalf("want %#v but got %#v", wantHTML.String(), gotHTML.String())
+	}
+	if got.HTML() != want.HTML() {
+		t.Fatalf("want %#v but got %#v", want.HTML(), got.HTML())
 	}
 }
 
@@ -44,7 +42,7 @@ func Example() {
 				dom.Attrs(),
 				dom.Text("10"),
 			),
-		).HTML(nil).String(),
+		).HTML(),
 	)
 	// Output: <div class="1 2 3" data-foo="4&lt;&#39;&#34;5&#34;&#39;&gt;6">&lt;oops&gt;789&lt;/oops&gt;<strong>10</strong></div>
 }
@@ -56,7 +54,7 @@ func ExampleAttrs() {
 				"href", "https://google.com",
 				"target", "_blank",
 			),
-		).HTML(nil).String(),
+		).HTML(),
 	)
 	// Output: <div href="https://google.com" target="_blank"></div>
 }
@@ -73,24 +71,24 @@ func ExampleElement() {
 				dom.Attrs(),
 				dom.Text("Google"),
 			),
-		).HTML(nil).String(),
+		).HTML(),
 	)
 	// Output: <a href="https://google.com" target="_blank">Goo&lt;g&gt;le<blockquote>Google</blockquote></a>
 }
 
 func ExampleText() {
 	fmt.Println(
-		dom.Text("Goo<g>le").HTML(nil).String(),
+		dom.Text("Goo<g>le").HTML(),
 	)
 	// Output: Goo&lt;g&gt;le
 }
 
 func BenchmarkAttrHTML(b *testing.B) {
+
 	for i := 0; i < b.N; i++ {
-		var sb strings.Builder
 		dom.Attrs(
 			"href", "https://google.com",
-		)[0].HTML(&sb).String()
+		)[0].HTML()
 	}
 	b.ReportAllocs()
 	b.ReportMetric(float64(b.N), "AttrHTML")
@@ -98,7 +96,6 @@ func BenchmarkAttrHTML(b *testing.B) {
 
 func BenchmarkNodeHTML(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		var sb strings.Builder
 		dom.A(
 			dom.Attrs(),
 			dom.Text("Goo<g>le"),
@@ -106,7 +103,7 @@ func BenchmarkNodeHTML(b *testing.B) {
 				dom.Attrs(),
 				dom.Text("Google"),
 			),
-		).HTML(&sb).String()
+		).HTML()
 	}
 	b.ReportAllocs()
 	b.ReportMetric(float64(b.N), "NodeHTML")

--- a/dom_test.go
+++ b/dom_test.go
@@ -84,7 +84,6 @@ func ExampleText() {
 }
 
 func BenchmarkAttrHTML(b *testing.B) {
-
 	for i := 0; i < b.N; i++ {
 		dom.Attrs(
 			"href", "https://google.com",
@@ -97,7 +96,10 @@ func BenchmarkAttrHTML(b *testing.B) {
 func BenchmarkNodeHTML(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		dom.A(
-			dom.Attrs(),
+			dom.Attrs(
+				"href", "https://google.com",
+				"target", "_blank",
+			),
 			dom.Text("Goo<g>le"),
 			dom.Blockquote(
 				dom.Attrs(),
@@ -120,6 +122,7 @@ func BenchmarkHtmlTemplate(b *testing.B) {
 		Text1  string
 		Text2  string
 	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		d := data{
 			Href:   "https://google.com",

--- a/dom_test.go
+++ b/dom_test.go
@@ -4,20 +4,22 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"strings"
 	"testing"
 
 	"github.com/choonkeat/dom-go"
 )
 
 func TestAttribute(t *testing.T) {
-	got := dom.Div(
+	var gotHTML, wantHTML strings.Builder
+	dom.Div(
 		dom.Attrs(
 			"class", "greeting",
 			"style", "color: red;",
 		),
 		dom.Text("Hello, world!"),
-	)
-	want := dom.Node{
+	).HTML(&gotHTML)
+	dom.Node{
 		Name: "div",
 		Attributes: []dom.Attribute{
 			{Name: "class", ValueText: "greeting"},
@@ -26,9 +28,9 @@ func TestAttribute(t *testing.T) {
 		Children: []dom.Node{
 			{InnerText: "Hello, world!"},
 		},
-	}
-	if got.HTML() != want.HTML() {
-		t.Fatalf("want %#v but got %#v", want.HTML(), got.HTML())
+	}.HTML(&wantHTML)
+	if gotHTML.String() != wantHTML.String() {
+		t.Fatalf("want %#v but got %#v", wantHTML.String(), gotHTML.String())
 	}
 }
 
@@ -42,7 +44,7 @@ func Example() {
 				dom.Attrs(),
 				dom.Text("10"),
 			),
-		).HTML(),
+		).HTML(nil).String(),
 	)
 	// Output: <div class="1 2 3" data-foo="4&lt;&#39;&#34;5&#34;&#39;&gt;6">&lt;oops&gt;789&lt;/oops&gt;<strong>10</strong></div>
 }
@@ -54,7 +56,7 @@ func ExampleAttrs() {
 				"href", "https://google.com",
 				"target", "_blank",
 			),
-		).HTML(),
+		).HTML(nil).String(),
 	)
 	// Output: <div href="https://google.com" target="_blank"></div>
 }
@@ -71,24 +73,24 @@ func ExampleElement() {
 				dom.Attrs(),
 				dom.Text("Google"),
 			),
-		).HTML(),
+		).HTML(nil).String(),
 	)
 	// Output: <a href="https://google.com" target="_blank">Goo&lt;g&gt;le<blockquote>Google</blockquote></a>
 }
 
 func ExampleText() {
 	fmt.Println(
-		dom.Text("Goo<g>le").HTML(),
+		dom.Text("Goo<g>le").HTML(nil).String(),
 	)
 	// Output: Goo&lt;g&gt;le
 }
 
 func BenchmarkAttrHTML(b *testing.B) {
-
 	for i := 0; i < b.N; i++ {
+		var sb strings.Builder
 		dom.Attrs(
 			"href", "https://google.com",
-		)[0].HTML()
+		)[0].HTML(&sb).String()
 	}
 	b.ReportAllocs()
 	b.ReportMetric(float64(b.N), "AttrHTML")
@@ -96,6 +98,7 @@ func BenchmarkAttrHTML(b *testing.B) {
 
 func BenchmarkNodeHTML(b *testing.B) {
 	for i := 0; i < b.N; i++ {
+		var sb strings.Builder
 		dom.A(
 			dom.Attrs(),
 			dom.Text("Goo<g>le"),
@@ -103,7 +106,7 @@ func BenchmarkNodeHTML(b *testing.B) {
 				dom.Attrs(),
 				dom.Text("Google"),
 			),
-		).HTML()
+		).HTML(&sb).String()
 	}
 	b.ReportAllocs()
 	b.ReportMetric(float64(b.N), "NodeHTML")


### PR DESCRIPTION
worth it?

[before](https://github.com/choonkeat/dom-go/actions/runs/6779812005/job/18427465970)
```

BenchmarkAttrHTML-2       	 5737236	       211.7 ns/op	   5737236 AttrHTML	      80 B/op	       2 allocs/op
BenchmarkNodeHTML-2       	 1534218	       786.0 ns/op	   1534218 NodeHTML	     232 B/op	       9 allocs/op
BenchmarkHtmlTemplate-2   	  143379	      8083 ns/op	    143379 HTMLTemplate	    1384 B/op	      53 allocs/op

```

[after](https://github.com/choonkeat/dom-go/actions/runs/6780041183/job/18428070446)
```

BenchmarkAttrHTML-2       	 4646418	       252.3 ns/op	   4646418 AttrHTML	     128 B/op	       4 allocs/op
BenchmarkNodeHTML-2       	 1818426	       657.4 ns/op	   1818426 NodeHTML	     240 B/op	       8 allocs/op
BenchmarkHtmlTemplate-2   	  140749	      8541 ns/op	    140749 HTMLTemplate	    1384 B/op	      53 allocs/op

```