### PR TITLE
fix: void element having closing tag / child

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -136,7 +136,15 @@ func (e Node) buildHTML(sb *strings.Builder) *strings.Builder {
 		sb.WriteString(" ")
 		attr.buildHTML(sb)
 	}
-	sb.WriteString(">")
+
+	switch e.Name {
+	case "area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr":
+		sb.WriteString("/>")
+		return sb
+	default:
+		sb.WriteString(">")
+	}
+
 	if e.InnerHTML != "" {
 		sb.WriteString(string(e.InnerHTML))
 	} else if e.InnerText != "" {
@@ -168,8 +176,8 @@ func Address(attrs []Attribute, children ...Node) Node {
 }
 
 // Area returns a Node with name "area".
-func Area(attrs []Attribute, children ...Node) Node {
-	return Element("area", attrs, children...)
+func Area(attrs []Attribute) Node {
+	return Element("area", attrs)
 }
 
 // Article returns a Node with name "article".
@@ -193,8 +201,8 @@ func B(attrs []Attribute, children ...Node) Node {
 }
 
 // Base returns a Node with name "base".
-func Base(attrs []Attribute, children ...Node) Node {
-	return Element("base", attrs, children...)
+func Base(attrs []Attribute) Node {
+	return Element("base", attrs)
 }
 
 // Bdi returns a Node with name "bdi".
@@ -248,8 +256,8 @@ func Code(attrs []Attribute, children ...Node) Node {
 }
 
 // Col returns a Node with name "col".
-func Col(attrs []Attribute, children ...Node) Node {
-	return Element("col", attrs, children...)
+func Col(attrs []Attribute) Node {
+	return Element("col", attrs)
 }
 
 // Colgroup returns a Node with name "colgroup".
@@ -313,8 +321,8 @@ func Em(attrs []Attribute, children ...Node) Node {
 }
 
 // Embed returns a Node with name "embed".
-func Embed(attrs []Attribute, children ...Node) Node {
-	return Element("embed", attrs, children...)
+func Embed(attrs []Attribute) Node {
+	return Element("embed", attrs)
 }
 
 // Fieldset returns a Node with name "fieldset".
@@ -508,8 +516,8 @@ func P(attrs []Attribute, children ...Node) Node {
 }
 
 // Param returns a Node with name "param".
-func Param(attrs []Attribute, children ...Node) Node {
-	return Element("param", attrs, children...)
+func Param(attrs []Attribute) Node {
+	return Element("param", attrs)
 }
 
 // Picture returns a Node with name "picture".

--- a/dom_test.go
+++ b/dom_test.go
@@ -34,6 +34,17 @@ func TestAttribute(t *testing.T) {
 	}
 }
 
+func TestInput(t *testing.T) {
+	t.Parallel()
+
+	got := dom.Input(dom.Attrs("name", "username"))
+	want := template.HTML(`<input name="username"/>`)
+
+	if got.HTML() != want {
+		t.Fatalf("want %#v but got %#v", want, got.HTML())
+	}
+}
+
 func Example() {
 	fmt.Println(
 		// use dom.Element or dom.Div


### PR DESCRIPTION
fix issue where void element includes closing tag and content

> A void element is an element whose content model never allows it to have contents under any circumstances. Void elements can have attributes.
> 
> The following is a complete list of the void elements in HTML:
> 
> area, base, br, col, command, embed, hr, img, input, keygen, link, meta, param, source, track, wbr

https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#syntax-elements